### PR TITLE
add gunicorn to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 appnope==0.1.0
+astroid==1.5.3
 bcrypt==3.1.4
 blinker==1.4
 certifi==2017.11.5
@@ -21,15 +22,19 @@ Flask-SQLAlchemy==2.3.2
 Flask-Testing==0.6.2
 Flask-User==0.6.19
 Flask-WTF==0.14.2
+gunicorn==19.7.1
 idna==2.6
 infinity==1.4
 intervals==0.8.0
 ipython==6.2.1
 ipython-genutils==0.2.0
+isort==4.2.15
 itsdangerous==0.24
 jedi==0.11.0
 Jinja2==2.9.6
+lazy-object-proxy==1.3.1
 MarkupSafe==1.0
+mccabe==0.6.1
 oauthlib==2.0.6
 parso==0.1.0
 passlib==1.7.1
@@ -42,6 +47,7 @@ ptyprocess==0.5.2
 pycparser==2.18
 pycryptodome==3.4.7
 Pygments==2.2.0
+pylint==1.7.4
 python-engineio==1.7.0
 python-socketio==1.8.1
 requests==2.18.4
@@ -59,5 +65,6 @@ visitor==0.1.3
 wcwidth==0.1.7
 Werkzeug==0.12.2
 win-unicode-console==0.5
+wrapt==1.10.11
 WTForms==2.1
 WTForms-Components==0.10.3


### PR DESCRIPTION
For some reason, we never include `gunicorn` package which is necessary for deployment. 